### PR TITLE
Change alacritty window property

### DIFF
--- a/alacritty/alacritty.toml
+++ b/alacritty/alacritty.toml
@@ -9,8 +9,7 @@ padding.y = 5
 
 dimensions.columns = 145
 dimensions.lines = 40
-
-decorations = "Buttonless"
+decorations = "None"
 option_as_alt = "Both"
 
 [font]


### PR DESCRIPTION
Current property `decorations` has value valid only for macos system. Value `None` make same effect and also valid for Ubuntu.